### PR TITLE
ENH: save database read from DGE and its cleaned version

### DIFF
--- a/covidmx/dge.py
+++ b/covidmx/dge.py
@@ -45,6 +45,7 @@ class DGE:
 
     def get_data(self, preserve_original=None):        
         if not self.data_path is None:
+            if not os.path.exists(self.data_path): os.mkdir(self.data_path)
             clean_data_file= os.path.join( self.data_path, os.path.split( URL_DATA )[1] ).replace("zip", "csv")     
         else: clean_data_file=""       
 

--- a/covidmx/tests/test_dge.py
+++ b/covidmx/tests/test_dge.py
@@ -1,11 +1,11 @@
 import pytest
 from covidmx import CovidMX
-
+import shutil 
 
 def test_returns_data():
     try:
-        covid_dge_data_saved = CovidMX(data_path="/data/covid/casos/database").get_data() #date='07-06-2020',    
-        
+        covid_dge_data_saved = CovidMX(data_path="./database").get_data() #date='07-06-2020',    
+        shutil.rmtree("./database")
         covid_dge_data = CovidMX().get_data()
         raw_dge_data = CovidMX(clean=False).get_data()
         covid_dge_data, catalogo_data = CovidMX(return_catalogo=True).get_data()

--- a/covidmx/tests/test_dge.py
+++ b/covidmx/tests/test_dge.py
@@ -4,6 +4,8 @@ from covidmx import CovidMX
 
 def test_returns_data():
     try:
+        covid_dge_data_saved = CovidMX(data_path="/data/covid/casos/database").get_data() #date='07-06-2020',    
+        
         covid_dge_data = CovidMX().get_data()
         raw_dge_data = CovidMX(clean=False).get_data()
         covid_dge_data, catalogo_data = CovidMX(return_catalogo=True).get_data()
@@ -13,5 +15,13 @@ def test_returns_data():
         historical_date = CovidMX(clean=False, date='04-12-2020', date_format='%m-%d-%Y').get_data()
         historical_date_1 = CovidMX(date='2020-04-12', date_format='%Y-%m-%d').get_data()
         historical_date_2 = CovidMX(clean=False, date='12-04-2020').get_data()
+
     except BaseException:
         assert False, "Test DGE failed"
+
+
+def main():
+    test_returns_data()
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ matplotlib==3.0.3
 mapclassify==2.2.0
 descartes==1.1.0
 wget>=1.0
-zipfile>=1.0
-shutil>=1.0 
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ matplotlib==3.0.3
 mapclassify==2.2.0
 descartes==1.1.0
 wget>=1.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ mapsmx==0.0.3
 matplotlib==3.0.3
 mapclassify==2.2.0
 descartes==1.1.0
+wget>=1.0
+os>=1.0
+zipfile>=1.0
+shutil>=1.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ matplotlib==3.0.3
 mapclassify==2.2.0
 descartes==1.1.0
 wget>=1.0
-os>=1.0
+os>=0.1
 zipfile>=1.0
 shutil>=1.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ matplotlib==3.0.3
 mapclassify==2.2.0
 descartes==1.1.0
 wget>=1.0
-os>=0.1
 zipfile>=1.0
 shutil>=1.0 


### PR DESCRIPTION
It will save 2 copies of database zip file in the data_path. One zip file is named with a day stamp to keep an historical archive the other is the one is used by default.

If the clean flag is used it will also save the cleaned csv database.  

Everyday if you want to update the database we only need to delete the default zipfile and cleaned database.